### PR TITLE
Make options optional

### DIFF
--- a/src/mobx-cookie.js
+++ b/src/mobx-cookie.js
@@ -46,11 +46,11 @@ class MobxCookie {
    * @param {*} value Cookie's value payload
    * @param {Object} options (optional) options to send to js-cookie
    */
-  set = action('[MOBX-COOKIE] Set', (value, options) => {
+  set = action('[MOBX-COOKIE] Set', (value, options = {}) => {
     this._clearTimeout()
     this.value = value
     jsCookie.set(this.name, this.value, options)
-    if (options && options.expires) {
+    if (options.expires) {
       // set _expires_ cookie, so that timer can be synced on reload.
       const expires = this._expiresToDateTime(options.expires)
       jsCookie.set(this.name + '-expires', expires, {

--- a/src/mobx-cookie.js
+++ b/src/mobx-cookie.js
@@ -50,7 +50,7 @@ class MobxCookie {
     this._clearTimeout()
     this.value = value
     jsCookie.set(this.name, this.value, options)
-    if (options.expires) {
+    if (options && options.expires) {
       // set _expires_ cookie, so that timer can be synced on reload.
       const expires = this._expiresToDateTime(options.expires)
       jsCookie.set(this.name + '-expires', expires, {


### PR DESCRIPTION
This should make the `options` argument optional when calling `set()`. Otherwise, calling `set()` without `options` results in an error: `Uncaught ReferenceError: options is not defined`